### PR TITLE
Add ability to reject request with a specific HTTP code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,15 +9,18 @@ pub fn accept_request() -> wapc_guest::CallResult {
     Ok(serde_json::to_vec(&ValidationResponse {
         accepted: true,
         message: None,
+        code: None,
     })?)
 }
 
 /// Create a rejection response
 /// # Arguments
 /// * `message` -  message shown to the user
-pub fn reject_request(message: Option<String>) -> wapc_guest::CallResult {
+/// * `code`    -  code shown to the user
+pub fn reject_request(message: Option<String>, code: Option<u16>) -> wapc_guest::CallResult {
     Ok(serde_json::to_vec(&ValidationResponse {
         accepted: false,
-        message: message,
+        message,
+        code,
     })?)
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -8,4 +8,6 @@ pub struct ValidationResponse {
     pub accepted: bool,
     /// Message shown to the user when the request is rejected
     pub message: Option<String>,
+    /// Code shown to the user when the request is rejected
+    pub code: Option<u16>,
 }


### PR DESCRIPTION
Besides the message, the Kubernetes API server allows webhooks to
specify the HTTP code when rejecting a request.